### PR TITLE
feat: add Entra ID (passwordless) authentication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,28 @@ EVENT_HUB_CONSUMER_GROUP=$Default
 EVENT_HUB_START_POSITION=latest   # or: earliest
 ```
 
+Alternatively, for **Entra ID (passwordless) authentication** — required when SAS keys are disabled on the namespace:
+
+```ini
+EVENT_HUB_NAMESPACE=your-ns.servicebus.windows.net
+EVENT_HUB_NAME=your-hub-name
+EVENT_HUB_CONSUMER_GROUP=$Default
+EVENT_HUB_START_POSITION=latest
+```
+
+> **Note:** Entra ID auth uses `DefaultAzureCredential` which picks up Azure CLI login, managed identity, environment variables, etc. Your identity must have the **Azure Event Hubs Data Receiver** role on the namespace or hub.
+
 ### Environment variables
 
 | Variable                      | Description                                                  | Default      |
 | ----------------------------- | ------------------------------------------------------------ | ------------ |
-| `EVENT_HUB_CONNECTION_STRING` | Primary connection string incl. `EntityPath=<your-hub-name>` | *(required)* |
+| `EVENT_HUB_CONNECTION_STRING` | Primary connection string incl. `EntityPath=<your-hub-name>` | —            |
+| `EVENT_HUB_NAMESPACE`         | Fully qualified namespace (e.g. `mynamespace.servicebus.windows.net`) — for Entra ID auth | —            |
+| `EVENT_HUB_NAME`              | Event Hub name — for Entra ID auth                           | —            |
 | `EVENT_HUB_CONSUMER_GROUP`    | Consumer group                                               | `$Default`   |
 | `EVENT_HUB_START_POSITION`    | `latest` (live only) or `earliest` (read full retention)     | `latest`     |
+
+> When both `EVENT_HUB_NAMESPACE`/`EVENT_HUB_NAME` and `EVENT_HUB_CONNECTION_STRING` are set, Entra ID is preferred.
 
 > **Tip:** If you deploy the Event Hub manually, configure [Diagnostic Settings](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings) on your Azure Firewall to forward logs to the `firewall-logs` Event Hub.
 

--- a/main.py
+++ b/main.py
@@ -61,9 +61,11 @@ def _load_env(path: Path, override: bool = False) -> None:
 
 _load_env(_BASE_DIR / ".env")
 
-# Run the setup wizard automatically if no connection string is configured.
+# Run the setup wizard automatically if no Event Hub credentials are configured.
 # Pass --reconfigure to redo setup even when .env already exists.
-if not os.environ.get("EVENT_HUB_CONNECTION_STRING") or "--reconfigure" in sys.argv:
+_has_conn_str = bool(os.environ.get("EVENT_HUB_CONNECTION_STRING"))
+_has_entra = bool(os.environ.get("EVENT_HUB_NAMESPACE") and os.environ.get("EVENT_HUB_NAME"))
+if (not _has_conn_str and not _has_entra) or "--reconfigure" in sys.argv:
     from setup_wizard import run_wizard  # noqa: E402
     run_wizard(_BASE_DIR, reconfigure="--reconfigure" in sys.argv)
     _load_env(_BASE_DIR / ".env", override=True)
@@ -208,20 +210,29 @@ class FirewallLogApp(App[None]):
         from azure.eventhub.aio import EventHubConsumerClient  # type: ignore[import]
 
         conn_str = os.environ.get("EVENT_HUB_CONNECTION_STRING", "")
+        eh_namespace = os.environ.get("EVENT_HUB_NAMESPACE", "")  # fully qualified, e.g. mynamespace.servicebus.windows.net
+        eh_name = os.environ.get("EVENT_HUB_NAME", "")
         consumer_group = os.environ.get("EVENT_HUB_CONSUMER_GROUP", "$Default")
         start_pos = os.environ.get("EVENT_HUB_START_POSITION", "latest")
         position = "@latest" if start_pos == "latest" else "@earliest"
+        use_entra = bool(eh_namespace and eh_name)
 
         status = self.query_one("#status", StatusBar)
 
-        if not conn_str:
+        if not conn_str and not use_entra:
             status.status = (
-                "ERROR: EVENT_HUB_CONNECTION_STRING not set — "
-                "copy .env.sample to .env and fill in the value"
+                "ERROR: No Event Hub credentials configured — set either "
+                "EVENT_HUB_NAMESPACE + EVENT_HUB_NAME (for Entra ID) or "
+                "EVENT_HUB_CONNECTION_STRING (for SAS key) in .env"
             )
             return
 
-        namespace, hub = _parse_eventhub_endpoint(conn_str)
+        # Resolve display values for the connecting dialog.
+        if use_entra:
+            namespace = eh_namespace
+            hub = eh_name
+        else:
+            namespace, hub = _parse_eventhub_endpoint(conn_str)
 
         # Keywords that indicate a configuration error rather than a transient fault.
         _AUTH_KEYWORDS = (
@@ -245,12 +256,27 @@ class FirewallLogApp(App[None]):
             status.status = "Connecting to Event Hub…"
 
             try:
-                async with EventHubConsumerClient.from_connection_string(
-                    conn_str,
-                    consumer_group=consumer_group,
-                    load_balancing_interval=1,  # claim partitions after 1s instead of default ~30s
-                    retry_total=0,              # no SDK-internal retries — our loop handles that
-                ) as client:
+                # Build the client — prefer Entra ID when namespace+hub are set.
+                if use_entra:
+                    from azure.identity.aio import DefaultAzureCredential  # type: ignore[import]
+                    _credential = DefaultAzureCredential()
+                    client = EventHubConsumerClient(
+                        fully_qualified_namespace=eh_namespace,
+                        eventhub_name=eh_name,
+                        consumer_group=consumer_group,
+                        credential=_credential,
+                        load_balancing_interval=1,
+                        retry_total=0,
+                    )
+                else:
+                    _credential = None
+                    client = EventHubConsumerClient.from_connection_string(
+                        conn_str,
+                        consumer_group=consumer_group,
+                        load_balancing_interval=1,
+                        retry_total=0,
+                    )
+                async with client:
                     # Probe the connection before starting the long-running receive().
                     # get_partition_ids() is a one-shot call without an internal reconnect
                     # loop, so it fails fast and visibly when the string is wrong or the
@@ -310,6 +336,8 @@ class FirewallLogApp(App[None]):
                     await client.receive(on_event=on_event, starting_position=position)
 
             except asyncio.CancelledError:
+                if _credential:
+                    await _credential.close()
                 if _splash_shown:
                     self._connecting_active = False
                     self.pop_screen()
@@ -317,6 +345,8 @@ class FirewallLogApp(App[None]):
                 return
 
             except Exception as exc:
+                if _credential:
+                    await _credential.close()
                 last_exc = exc
                 self._fw_name_set = False  # allow subtitle refresh on next connect
                 attempt += 1
@@ -338,10 +368,17 @@ class FirewallLogApp(App[None]):
             err_lower = str(last_exc).lower()
             is_cfg_error = any(kw in err_lower for kw in _AUTH_KEYWORDS)
             if is_cfg_error:
-                hint = (
-                    "The credentials in your connection string were rejected.\n"
-                    "Restart the app with  --reconfigure  to update the settings."
-                )
+                if use_entra:
+                    hint = (
+                        "Entra ID authentication was rejected.\n"
+                        "Ensure your identity has the 'Azure Event Hubs Data Receiver' role\n"
+                        "on the Event Hub namespace or entity, then restart the app."
+                    )
+                else:
+                    hint = (
+                        "The credentials in your connection string were rejected.\n"
+                        "Restart the app with  --reconfigure  to update the settings."
+                    )
             else:
                 hint = (
                     "The Event Hub namespace could not be reached.\n"

--- a/main.py
+++ b/main.py
@@ -250,6 +250,7 @@ class FirewallLogApp(App[None]):
         self._connecting_active = True
         await self.push_screen(_dialog)
         _splash_shown = True
+        _credential = None  # track credential for cleanup on error
 
         while attempt < _MAX_ATTEMPTS:
             self.sub_title = "Live Log Monitor  |  connecting..."

--- a/main.py
+++ b/main.py
@@ -161,7 +161,7 @@ class FirewallLogApp(App[None]):
             "Action", "Policy / Info",
         )
         self._start_stream()
-        self.set_interval(1.0, self._flush)
+        self.set_interval(1.0, self._flush_rows)
         self._check_update()
 
     # ── Update check ────────────────────────────────────────────────────────────
@@ -278,68 +278,71 @@ class FirewallLogApp(App[None]):
                         load_balancing_interval=1,
                         retry_total=0,
                     )
-                async with client:
-                    # Probe the connection before starting the long-running receive().
-                    # get_partition_ids() is a one-shot call without an internal reconnect
-                    # loop, so it fails fast and visibly when the string is wrong or the
-                    # namespace is unreachable.
-                    try:
-                        await asyncio.wait_for(client.get_partition_ids(), timeout=15)
-                    except asyncio.TimeoutError:
-                        raise TimeoutError(
-                            "Event Hub did not respond within 15 s — "
-                            "check connection string and network"
-                        )
-
-                    attempt = 0  # reset backoff counter after a successful connect
-                    if _splash_shown:
-                        _dialog.show_waiting()
-                    status.status = "Connected"
-                    self.sub_title = "Live Log Monitor  |  connected"
-
-                    async def on_event(partition_ctx, event) -> None:  # type: ignore[misc]
-                        nonlocal _splash_shown
-                        if event is None or self._paused:
-                            return
+                try:
+                    async with client:
+                        # Probe the connection before starting the long-running receive().
+                        # get_partition_ids() is a one-shot call without an internal reconnect
+                        # loop, so it fails fast and visibly when the string is wrong or the
+                        # namespace is unreachable.
                         try:
-                            body = json.loads(event.body_as_str())
-                        except (ValueError, TypeError):
-                            return
-                        has_real = False
-                        for rec in body.get("records", []):
-                            if not self._fw_name_set:
-                                rid: str = rec.get("resourceId", "")
-                                if "/AZUREFIREWALLS/" in rid.upper():
-                                    self.sub_title = rid.split("/")[-1]
-                                    self._fw_name_set = True
-                            row = parse_record(rec)
-                            if row is None:
-                                continue
-                            if "SKIP:" in row.category:
-                                self._skip_pending += 1
-                            else:
-                                self._pending.append(row)
-                                has_real = True
-                        if has_real and _splash_shown:
-                            _splash_shown = False
-                            self._connecting_active = False
-                            if isinstance(self.screen, UpdateDialog):
-                                # UpdateDialog is on top of ConnectingDialog.
-                                # Save its state, pop both, re-push UpdateDialog.
-                                upd_tag = self.screen._latest
-                                upd_url = self.screen._url
-                                self._pending_update = None
-                                self.pop_screen()   # remove UpdateDialog
-                                self.pop_screen()   # remove ConnectingDialog
-                                await self.push_screen(UpdateDialog(upd_tag, upd_url))
-                            else:
-                                self.pop_screen()   # remove ConnectingDialog
+                            await asyncio.wait_for(client.get_partition_ids(), timeout=15)
+                        except asyncio.TimeoutError:
+                            raise TimeoutError(
+                                "Event Hub did not respond within 15 s — "
+                                "check connection string and network"
+                            )
 
-                    await client.receive(on_event=on_event, starting_position=position)
+                        attempt = 0  # reset backoff counter after a successful connect
+                        if _splash_shown:
+                            _dialog.show_waiting()
+                        status.status = "Connected"
+                        self.sub_title = "Live Log Monitor  |  connected"
+
+                        async def on_event(partition_ctx, event) -> None:  # type: ignore[misc]
+                            nonlocal _splash_shown
+                            if event is None or self._paused:
+                                return
+                            try:
+                                body = json.loads(event.body_as_str())
+                            except (ValueError, TypeError):
+                                return
+                            has_real = False
+                            for rec in body.get("records", []):
+                                if not self._fw_name_set:
+                                    rid: str = rec.get("resourceId", "")
+                                    if "/AZUREFIREWALLS/" in rid.upper():
+                                        self.sub_title = rid.split("/")[-1]
+                                        self._fw_name_set = True
+                                row = parse_record(rec)
+                                if row is None:
+                                    continue
+                                if "SKIP:" in row.category:
+                                    self._skip_pending += 1
+                                else:
+                                    self._pending.append(row)
+                                    has_real = True
+                            if has_real and _splash_shown:
+                                _splash_shown = False
+                                self._connecting_active = False
+                                if isinstance(self.screen, UpdateDialog):
+                                    # UpdateDialog is on top of ConnectingDialog.
+                                    # Save its state, pop both, re-push UpdateDialog.
+                                    upd_tag = self.screen._latest
+                                    upd_url = self.screen._url
+                                    self._pending_update = None
+                                    self.pop_screen()   # remove UpdateDialog
+                                    self.pop_screen()   # remove ConnectingDialog
+                                    await self.push_screen(UpdateDialog(upd_tag, upd_url))
+                                else:
+                                    self.pop_screen()   # remove ConnectingDialog
+
+                        await client.receive(on_event=on_event, starting_position=position)
+                finally:
+                    if _credential:
+                        await _credential.close()
+                        _credential = None
 
             except asyncio.CancelledError:
-                if _credential:
-                    await _credential.close()
                 if _splash_shown:
                     self._connecting_active = False
                     self.pop_screen()
@@ -347,8 +350,6 @@ class FirewallLogApp(App[None]):
                 return
 
             except Exception as exc:
-                if _credential:
-                    await _credential.close()
                 last_exc = exc
                 self._fw_name_set = False  # allow subtitle refresh on next connect
                 attempt += 1
@@ -394,7 +395,7 @@ class FirewallLogApp(App[None]):
             await self.push_screen(ErrorDialog(str(last_exc), hint))
 
     # ── periodic flush ──────────────────────────────────────────────────────────
-    async def _flush(self) -> None:
+    async def _flush_rows(self) -> None:
         """Drain pending rows into _all_rows and refresh the table (every 1 s)."""
         has_new = bool(self._pending) or self._skip_pending > 0
         if not has_new:

--- a/main.py
+++ b/main.py
@@ -259,8 +259,9 @@ class FirewallLogApp(App[None]):
             try:
                 # Build the client — prefer Entra ID when namespace+hub are set.
                 if use_entra:
+                    from azure.core.pipeline.transport import AsyncioRequestsTransport  # noqa: E402
                     from azure.identity.aio import DefaultAzureCredential  # type: ignore[import]
-                    _credential = DefaultAzureCredential()
+                    _credential = DefaultAzureCredential(transport=AsyncioRequestsTransport())
                     client = EventHubConsumerClient(
                         fully_qualified_namespace=eh_namespace,
                         eventhub_name=eh_name,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 azure-eventhub>=5.11.0
+azure-identity>=1.15.0
 python-dotenv>=1.0.0
 textual>=0.63.0

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -2,13 +2,14 @@
 """
 Cross-platform setup wizard for fw-log-tui.
 
-Checks for Azure CLI, verifies login, and writes the Event Hub connection
-string to .env.  Works on Linux, macOS, and Windows.
+Checks for Azure CLI, verifies login, and writes Event Hub credentials
+to .env (either a connection string or Entra ID namespace/hub config).
+Works on Linux, macOS, and Windows.
 
 Usage (standalone):
     python setup_wizard.py [--reconfigure]
 
-Called automatically by main.py when EVENT_HUB_CONNECTION_STRING is not set.
+Called automatically by main.py when no Event Hub credentials are configured.
 """
 from __future__ import annotations
 
@@ -71,6 +72,7 @@ def show_menu() -> None:
     print("    1)  Choose from existing Event Hubs in my subscriptions")
     print("    2)  Discover firewall, deploy Event Hub + configure diagnostics  (~2–3 min)")
     print("    3)  Paste a connection string directly")
+    print("    4)  Use Entra ID (passwordless)  — enter namespace + hub name")
     print("    q)  Quit")
     print()
 
@@ -102,6 +104,44 @@ def paste_connection_string(env_file: Path) -> bool:
                 continue
         write_env(env_file, raw)
         return True
+
+
+# ── 3d. Entra ID (passwordless) setup ─────────────────────────────────────────
+def setup_entra_id(env_file: Path) -> bool:
+    print()
+    print(f"  {bold('Entra ID (passwordless) authentication')}")
+    print(f"  {_c('36', 'No secrets are stored — authentication uses DefaultAzureCredential')}")
+    print(f"  {_c('36', '(Azure CLI login, managed identity, environment credentials, etc.)')}")
+    print()
+    print(f"  {_c('33', 'Prerequisite:')} Your identity must have the")
+    print(f"  {bold('Azure Event Hubs Data Receiver')} role on the namespace or hub.")
+    print()
+
+    while True:
+        namespace = input("  Fully qualified namespace (e.g. mynamespace.servicebus.windows.net) or q to go back: ").strip()
+        if namespace.lower() == "q":
+            return False
+        if not namespace:
+            warn("Namespace must not be empty.")
+            continue
+        if not namespace.endswith(".servicebus.windows.net"):
+            warn("Expected format: <name>.servicebus.windows.net")
+            retry = input("  Use it anyway? [y/N]: ").strip().lower()
+            if retry != "y":
+                continue
+        break
+
+    while True:
+        hub_name = input("  Event Hub name: ").strip()
+        if hub_name.lower() == "q":
+            return False
+        if not hub_name:
+            warn("Event Hub name must not be empty.")
+            continue
+        break
+
+    write_env_entra(env_file, namespace, hub_name)
+    return True
 
 
 # ── Azure CLI checks ───────────────────────────────────────────────────────────
@@ -139,6 +179,7 @@ def check_login() -> None:
 
 # ── .env helpers ───────────────────────────────────────────────────────────────
 def get_existing_conn_str(env_file: Path) -> Optional[str]:
+    """Return a non-empty connection string from .env, or None."""
     if not env_file.exists():
         return None
     for line in env_file.read_text(encoding="utf-8").splitlines():
@@ -148,13 +189,44 @@ def get_existing_conn_str(env_file: Path) -> Optional[str]:
     return None
 
 
+def has_entra_config(env_file: Path) -> bool:
+    """Return True if .env has EVENT_HUB_NAMESPACE and EVENT_HUB_NAME set."""
+    if not env_file.exists():
+        return False
+    found_ns = found_name = False
+    for line in env_file.read_text(encoding="utf-8").splitlines():
+        if line.startswith("EVENT_HUB_NAMESPACE=") and line.split("=", 1)[1].strip():
+            found_ns = True
+        if line.startswith("EVENT_HUB_NAME=") and line.split("=", 1)[1].strip():
+            found_name = True
+    return found_ns and found_name
+
+
 def write_env(env_file: Path, conn_str: str) -> None:
+    """Write a connection-string-based .env file."""
     from datetime import datetime, timezone
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     env_file.write_text(
         f"# Written by setup_wizard.py - {ts}\n"
         "# Do NOT commit this file - it contains a shared access key.\n"
         f"EVENT_HUB_CONNECTION_STRING={conn_str}\n"
+        "EVENT_HUB_CONSUMER_GROUP=$Default\n"
+        "EVENT_HUB_START_POSITION=latest\n",
+        encoding="utf-8",
+    )
+    ok(f".env written to {env_file}")
+
+
+def write_env_entra(env_file: Path, namespace: str, hub_name: str) -> None:
+    """Write an Entra ID (passwordless) .env file."""
+    from datetime import datetime, timezone
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    env_file.write_text(
+        f"# Written by setup_wizard.py - {ts}\n"
+        "# Entra ID (passwordless) authentication — no secrets stored.\n"
+        "# Your identity must have 'Azure Event Hubs Data Receiver' role.\n"
+        f"EVENT_HUB_NAMESPACE={namespace}\n"
+        f"EVENT_HUB_NAME={hub_name}\n"
         "EVENT_HUB_CONSUMER_GROUP=$Default\n"
         "EVENT_HUB_START_POSITION=latest\n",
         encoding="utf-8",
@@ -576,7 +648,7 @@ def run_wizard(base_dir: Path, reconfigure: bool = False) -> None:
     env_file = base_dir / ".env"
 
     # Skip if already configured
-    if not reconfigure and get_existing_conn_str(env_file):
+    if not reconfigure and (get_existing_conn_str(env_file) or has_entra_config(env_file)):
         return
 
     print_header()
@@ -593,7 +665,7 @@ def run_wizard(base_dir: Path, reconfigure: bool = False) -> None:
     while True:
         print()
         show_menu()
-        choice = input("  Choice [1/2/3/q]: ").strip().lower()
+        choice = input("  Choice [1/2/3/4/q]: ").strip().lower()
         print()
         if choice == "1":
             _ensure_az()
@@ -606,11 +678,14 @@ def run_wizard(base_dir: Path, reconfigure: bool = False) -> None:
         elif choice == "3":
             if paste_connection_string(env_file):
                 break
+        elif choice == "4":
+            if setup_entra_id(env_file):
+                break
         elif choice == "q":
             print("  Bye.")
             sys.exit(0)
         else:
-            warn("Please enter 1, 2, 3, or q.")
+            warn("Please enter 1, 2, 3, 4, or q.")
 
     print()
     ok("Setup complete — launching the TUI…")

--- a/setup_wizard.py
+++ b/setup_wizard.py
@@ -2,9 +2,8 @@
 """
 Cross-platform setup wizard for fw-log-tui.
 
-Checks for Azure CLI, verifies login, and writes Event Hub credentials
-to .env (either a connection string or Entra ID namespace/hub config).
-Works on Linux, macOS, and Windows.
+Checks for Azure CLI / verifies login when needed (for subscription discovery/deploy flows)
+and writes Event Hub credentials to .env (either a connection string or Entra ID namespace/hub config).
 
 Usage (standalone):
     python setup_wizard.py [--reconfigure]
@@ -132,7 +131,7 @@ def setup_entra_id(env_file: Path) -> bool:
         break
 
     while True:
-        hub_name = input("  Event Hub name: ").strip()
+        hub_name = input("  Event Hub name (or q to go back): ").strip()
         if hub_name.lower() == "q":
             return False
         if not hub_name:


### PR DESCRIPTION
## Summary

Add support for Microsoft Entra ID authentication as an alternative to SAS key connection strings. This is required when the Event Hub namespace has local authentication disabled (SAS key lock).

## Changes

- **main.py**: Support `EVENT_HUB_NAMESPACE` + `EVENT_HUB_NAME` env vars to authenticate via `DefaultAzureCredential` instead of `from_connection_string()`. Entra ID is preferred when both methods are configured. Includes proper credential cleanup on cancellation/error.
- **setup_wizard.py**: Add option 4 *'Use Entra ID (passwordless)'* to the setup menu. Prompts for fully qualified namespace and hub name, then writes a secret-free `.env`. The wizard now detects existing Entra config to avoid re-triggering.
- **requirements.txt**: Add `azure-identity>=1.15.0` dependency.
- **README.md**: Document Entra ID configuration, new environment variables, and RBAC prerequisites.

## How to use

Set these in `.env` (or select option 4 in the setup wizard):

```ini
EVENT_HUB_NAMESPACE=your-ns.servicebus.windows.net
EVENT_HUB_NAME=your-hub-name
```

The signed-in identity (via `az login`, managed identity, etc.) must have the **Azure Event Hubs Data Receiver** role on the namespace or hub.

## Testing

- Verified against an Event Hub namespace with SAS keys disabled
- Existing connection string auth path is unchanged (backward compatible)