### PR TITLE
fix: address Copilot review findings from #6 and #7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to **Azure Firewall Watch** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Legacy `AzureFirewallDNSResolutionFailureLog` messages without an `Error …` part crashed the parser and were counted as parse errors.
+- The row index used by the detail dialog grew without bound when a restrictive filter kept rows out of the table for a long session; it now only holds rows that are actually in the table.
+- `EVENT_HUB_START_POSITION` is case-insensitive (`LATEST`, `Earliest`), and any other value is passed to the SDK unchanged so a raw offset or sequence number can be used.
+
 ## [0.4.0] - 2026-09-05
 
 New log categories (`FlowTrace`, `FatFlow`, `DnsFailure`), automatic reconnects, a much cheaper table refresh, a full test suite with CI, and a batch of bugs the tests and a lab firewall surfaced — including `earliest` never delivering events and `Escape`/`q` misbehaving in dialogs.
@@ -116,6 +124,7 @@ This release adds passwordless Entra ID authentication, better Azure Firewall lo
 
 [Full diff](https://github.com/cloudchristoph/az-firewall-watch/commits/v0.1.0)
 
+[Unreleased]: https://github.com/cloudchristoph/az-firewall-watch/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/cloudchristoph/az-firewall-watch/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/cloudchristoph/az-firewall-watch/releases/tag/v0.3.0
 [0.2.1]: https://github.com/cloudchristoph/az-firewall-watch/releases/tag/v0.2.1

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ EVENT_HUB_START_POSITION=latest
 | `EVENT_HUB_NAMESPACE`         | Fully qualified namespace (e.g. `mynamespace.servicebus.windows.net`) — for Entra ID auth | —          |
 | `EVENT_HUB_NAME`              | Event Hub name — for Entra ID auth                                                        | —          |
 | `EVENT_HUB_CONSUMER_GROUP`    | Consumer group                                                                            | `$Default` |
-| `EVENT_HUB_START_POSITION`    | `latest` (only new events) or `earliest` (replay the hub's full retention first)          | `latest`   |
+| `EVENT_HUB_START_POSITION`    | `latest` (only new events) or `earliest` (replay the hub's full retention first); other values are passed to the SDK as a raw offset | `latest`   |
 <!-- markdownlint-enable MD060 -->
 
 > When both `EVENT_HUB_NAMESPACE`/`EVENT_HUB_NAME` and `EVENT_HUB_CONNECTION_STRING` are set, Entra ID is preferred.

--- a/fw_parser.py
+++ b/fw_parser.py
@@ -418,7 +418,7 @@ def _parse_legacy(record: dict, op_name: str, time: str) -> FirewallDataRow:
             head, _, tail = msg.partition(" Rule Collection: ")
             m = _RESOLVE_FAIL_RE.match(head)
             fqdn = m.group("fqdn") if m else "-"
-            error = (m.group("error") if m else head).rstrip(".")
+            error = ((m.group("error") or "") if m else head).rstrip(".")
             rc_path, _, rule_part = tail.partition(". Rule: ")
             segments = rc_path.split(":")  # policy:rcg:rc (older firewalls may omit parts)
             fw_policy, rcg, rc = (segments + ["", "", ""])[:3] if len(segments) >= 3 else ("", "", rc_path)

--- a/tests/test_app_filtering.py
+++ b/tests/test_app_filtering.py
@@ -304,3 +304,12 @@ async def test_row_index_stays_bounded_under_restrictive_filter(structured_recor
         await pilot.pause()
         assert tbl.row_count == 20
         assert set(app._row_index) == {r.rowid for r in app._all_rows}
+        # A full rebuild under a filter indexes only the visible rows
+        app.query_one("#f-hide-dns", Switch).value = False  # triggers _refresh_table
+        app.query_one("#f-action", Input).value = "allow"
+        await pilot.pause()
+        assert tbl.row_count == 20
+        app.query_one("#f-action", Input).value = "deny"
+        await pilot.pause()
+        assert tbl.row_count == 0
+        assert app._row_index == {}

--- a/tests/test_app_filtering.py
+++ b/tests/test_app_filtering.py
@@ -284,3 +284,23 @@ async def test_selected_row_stays_selected_when_rows_arrive(structured_record):
         await _inject(app, pilot, [_net(structured_record, f"2026-09-05T08:00:1{i}Z") for i in range(5)])
         assert tbl.cursor_row == 6  # five newer rows were inserted above it
         assert tbl.coordinate_to_cell_key((tbl.cursor_row, 0)).row_key.value == rows[1].rowid
+
+
+async def test_row_index_stays_bounded_under_restrictive_filter(structured_record, monkeypatch):
+    """Regression (Copilot review): rows filtered out on arrival must not accumulate in _row_index."""
+    monkeypatch.setattr(app_module, "MAX_ROWS", 20)
+    app = FirewallLogApp()
+    async with app.run_test(size=(140, 40)) as pilot:
+        await pilot.pause()
+        app.query_one("#f-action", Input).value = "deny"
+        await pilot.pause()
+        for i in range(10):
+            await _inject(app, pilot, [_net(structured_record, f"2026-09-05T08:{i:02d}:{j:02d}Z") for j in range(5)])
+        tbl = app.query_one("#log-table", DataTable)
+        assert tbl.row_count == 0                      # nothing matches "deny"
+        assert len(app._row_index) == 0                # … so nothing is indexed
+        assert len(app._all_rows) == 20
+        app.query_one("#f-action", Input).value = ""
+        await pilot.pause()
+        assert tbl.row_count == 20
+        assert set(app._row_index) == {r.rowid for r in app._all_rows}

--- a/tests/test_fw_parser_legacy.py
+++ b/tests/test_fw_parser_legacy.py
@@ -149,6 +149,18 @@ def test_legacy_dns_resolution_failure_without_rule_info(legacy_record):
     assert row.policy == ""
 
 
+def test_legacy_dns_resolution_failure_without_error_text(legacy_record):
+    """Regression (Copilot review): the optional 'Error …' group must not crash the parser."""
+    row = parse_record(legacy_record(
+        "AzureFirewallNetworkRule", "AzureFirewallDNSResolutionFailureLog",
+        "Failed to resolve FQDN nope.invalid. Rule Collection: pol:rcg:rc. Rule: r",
+    ))
+    assert row.category == "DnsFailure"
+    assert row.targetip == "nope.invalid"
+    assert row.moreinfo == ""
+    assert row.policy == "pol»rcg»rc»r"
+
+
 def test_legacy_malformed_message_is_counted_as_parse_error(legacy_record):
     row = parse_record(legacy_record(
         "AzureFirewallNetworkRule", "AzureFirewallNetworkRuleLog", "garbage without structure",

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -538,6 +538,26 @@ async def test_credentials_are_closed_on_every_transient_failure(monkeypatch, fa
         assert all(c.closed for c in fake_credential.instances)
 
 
+# ── start position ───────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("latest", "@latest"),
+        ("LATEST", "@latest"),
+        ("", "@latest"),
+        ("@latest", "@latest"),
+        ("earliest", "-1"),
+        ("Earliest ", "-1"),
+        ("-1", "-1"),
+        ("12345", "12345"),           # raw offset passed through
+        ("2026-09-05T08:00:00Z", "2026-09-05T08:00:00Z"),
+    ],
+)
+def test_resolve_start_position(value, expected):
+    assert streaming.resolve_start_position(value) == expected
+
+
 # ── _error_hint ──────────────────────────────────────────────────────────────
 
 def test_error_hint_variants():

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -549,7 +549,9 @@ async def test_credentials_are_closed_on_every_transient_failure(monkeypatch, fa
         ("@latest", "@latest"),
         ("earliest", "-1"),
         ("Earliest ", "-1"),
+        ("@earliest", "-1"),          # SDK-style spelling; previously matched nothing
         ("-1", "-1"),
+        (None, "@latest"),
         ("12345", "12345"),           # raw offset passed through
         ("2026-09-05T08:00:00Z", "2026-09-05T08:00:00Z"),
     ],

--- a/viewer/app.py
+++ b/viewer/app.py
@@ -257,9 +257,9 @@ class FirewallLogApp(App[None]):
                 if self._matches(row, f):
                     tbl.add_row(*self._render_cells(row, f, single_policy), key=row.rowid)
                     # Index only what is in the table (rows may linger there
-                    # beyond _all_rows until the next trim); the index is
-                    # rebuilt from _all_rows on every full refresh, so it
-                    # stays bounded by max(MAX_ROWS, table size).
+                    # beyond _all_rows until the next trim); every full refresh
+                    # rebuilds the index from the visible rows, so it stays
+                    # bounded by the table size.
                     self._row_index[row.rowid] = row
                     added += 1
             if added:
@@ -277,7 +277,7 @@ class FirewallLogApp(App[None]):
         """Full rebuild of the table from _all_rows (filter changes, trimming)."""
         f = self._get_filters()
         visible = [r for r in self._all_rows if self._matches(r, f)]
-        self._row_index = {r.rowid: r for r in self._all_rows}
+        self._row_index = {r.rowid: r for r in visible}  # exactly the rows in the table
         tbl = self.query_one("#log-table", DataTable)
         prev_scroll_y = tbl.scroll_y
         prev_rowid = self._selected_rowid

--- a/viewer/app.py
+++ b/viewer/app.py
@@ -124,7 +124,7 @@ class FirewallLogApp(App[None]):
         self._fw_name_set: bool = False
         self._seen_policies: set[str] = set()
         self._selected_rowid: str | None = None
-        # rowid → row for everything currently shown or buffered
+        # rowid → row for every row currently in the table (detail dialog lookup)
         self._row_index: dict[str, FirewallDataRow] = {}
 
     # ── layout ─────────────────────────────────────────────────────────────────
@@ -195,10 +195,6 @@ class FirewallLogApp(App[None]):
         batch.sort(key=_row_time, reverse=True)
         merged = list(heapq.merge(batch, self._all_rows, key=_row_time, reverse=True))
         self._all_rows = merged[:MAX_ROWS]
-        # Rows that just fell off _all_rows may linger in the table until the
-        # next trim; keep them addressable for the detail dialog meanwhile.
-        for r in batch:
-            self._row_index[r.rowid] = r
 
         tbl = self.query_one("#log-table", DataTable)
         needs_full_rebuild = (
@@ -260,6 +256,11 @@ class FirewallLogApp(App[None]):
             for row in batch:
                 if self._matches(row, f):
                     tbl.add_row(*self._render_cells(row, f, single_policy), key=row.rowid)
+                    # Index only what is in the table (rows may linger there
+                    # beyond _all_rows until the next trim); the index is
+                    # rebuilt from _all_rows on every full refresh, so it
+                    # stays bounded by max(MAX_ROWS, table size).
+                    self._row_index[row.rowid] = row
                     added += 1
             if added:
                 tbl.sort(key=_time_cell_key, reverse=True)

--- a/viewer/streaming.py
+++ b/viewer/streaming.py
@@ -112,16 +112,18 @@ def resolve_start_position(value: str) -> str:
     """Map EVENT_HUB_START_POSITION to the SDK's starting_position.
 
     ``latest`` → ``"@latest"`` (only new events), ``earliest`` → ``"-1"``
-    (beginning of retention), both case-insensitive; anything else is passed
-    through unchanged so a raw offset or sequence number can be used.
-    An empty value means ``latest``.
+    (beginning of retention), both case-insensitive and also accepted in the
+    SDK spellings ``@latest`` / ``@earliest``; anything else is passed through
+    unchanged so a raw offset or sequence number can be used. An empty or
+    missing value means ``latest``.
     """
-    normalised = (value or "").strip().lower()
+    raw = (value or "").strip()
+    normalised = raw.lower()
     if normalised in ("", "latest", "@latest"):
         return "@latest"
-    if normalised in ("earliest", "-1"):
+    if normalised in ("earliest", "@earliest", "-1"):
         return "-1"
-    return value.strip()
+    return raw
 
 
 async def _remove_splash(app: "FirewallLogApp") -> None:

--- a/viewer/streaming.py
+++ b/viewer/streaming.py
@@ -108,6 +108,22 @@ async def _verify_data_plane_access(credential, eh_namespace: str) -> None:
         )
 
 
+def resolve_start_position(value: str) -> str:
+    """Map EVENT_HUB_START_POSITION to the SDK's starting_position.
+
+    ``latest`` → ``"@latest"`` (only new events), ``earliest`` → ``"-1"``
+    (beginning of retention), both case-insensitive; anything else is passed
+    through unchanged so a raw offset or sequence number can be used.
+    An empty value means ``latest``.
+    """
+    normalised = (value or "").strip().lower()
+    if normalised in ("", "latest", "@latest"):
+        return "@latest"
+    if normalised in ("earliest", "-1"):
+        return "-1"
+    return value.strip()
+
+
 async def _remove_splash(app: "FirewallLogApp") -> None:
     """Remove the ConnectingDialog from the screen stack.
 
@@ -160,10 +176,7 @@ async def run_stream(app: "FirewallLogApp") -> None:
     eh_name = os.environ.get("EVENT_HUB_NAME", "")
     consumer_group = os.environ.get("EVENT_HUB_CONSUMER_GROUP", "$Default")
     start_pos = os.environ.get("EVENT_HUB_START_POSITION", "latest")
-    # SDK contract: "@latest" = only new events, "-1" = beginning of retention.
-    # Any other string is treated as a raw offset, so "@earliest" silently
-    # matched nothing.
-    position = "@latest" if start_pos == "latest" else "-1"
+    position = resolve_start_position(start_pos)
     use_entra = bool(eh_namespace and eh_name)
 
     status = app.query_one("#status", StatusBar)

--- a/viewer/streaming.py
+++ b/viewer/streaming.py
@@ -108,7 +108,7 @@ async def _verify_data_plane_access(credential, eh_namespace: str) -> None:
         )
 
 
-def resolve_start_position(value: str) -> str:
+def resolve_start_position(value: str | None) -> str:
     """Map EVENT_HUB_START_POSITION to the SDK's starting_position.
 
     ``latest`` → ``"@latest"`` (only new events), ``earliest`` → ``"-1"``


### PR DESCRIPTION
Copilot's review comments on #6 and #7 were valid and had not been acted on before merging:

- **Parser crash** (`fw_parser.py`): legacy `AzureFirewallDNSResolutionFailureLog` without an `Error …` part hit `None.rstrip()` and was counted as a parse error.
- **Unbounded `_row_index`** (`viewer/app.py`): every arriving row was indexed but the index was only reset on a full table rebuild, which never happens while a restrictive filter keeps the table small. Now only rows in the table are indexed.
- **Start position** (`viewer/streaming.py`): `latest`/`earliest` are matched case-insensitively; other values pass through to the SDK as raw offsets.

Regression tests for all three; 294 tests green.